### PR TITLE
Add check for empty/none username and password

### DIFF
--- a/TA-webtools/bin/input_module_curl_inputs.py
+++ b/TA-webtools/bin/input_module_curl_inputs.py
@@ -33,7 +33,8 @@ def collect_events(helper, ew):
     header = helper.get_arg('request_headers')
     payload = helper.get_arg('payload')
     user = helper.get_arg('username')
-    passwd = helper.get_arg('password')    
+    passwd = helper.get_arg('password')
+    auth = (user, passwd)    
     if method.lower() in ("get","g"):
         method = "get"
     if method.lower() in ("post","put","p"):
@@ -48,6 +49,8 @@ def collect_events(helper, ew):
         headers=json.loads(header)
     else:
         headers=None
+    if (bool(user)==False and bool(passwd)==False):
+        auth=None
     
     data = {}
     data['curl_uri'] = uri
@@ -57,7 +60,7 @@ def collect_events(helper, ew):
     data['curl_payload'] = payload
     
     try:
-        r = requests.request(method, uri, auth=(user,passwd), data=payload, headers=headers, cookies=None, verify=verifyssl, cert=None, timeout=None)
+        r = requests.request(method, uri, auth=auth, data=payload, headers=headers, cookies=None, verify=verifyssl, cert=None, timeout=None)
         data['curl_response'] = r.text
         data['curl_status'] = r.status_code
 


### PR DESCRIPTION
When using the modular input the username/password tupel is passed to basic auth even if they are empty/null.  This prevents the use of the Authorization header for other authorisation mechanisms (e.g. Bearer/token) Authentication.

This code changes adds a check for empty/None username and password passing None into auth and allowing the Authorization header to work correctly.
