### PR TITLE
Enable enforce HTTPS Optional 

### DIFF
--- a/TA-webtools/bin/curl.py
+++ b/TA-webtools/bin/curl.py
@@ -301,7 +301,11 @@ def execute():
                             data = str(result[options['datafield']])
                     else:
                         data = None
-
+                    # We enable users at their risk to do http queries instead of https, while not recommended it is good to allow users freedom
+                    if 'enforcehttps'  in options:
+                        enforcehttps=options['enforcehttps']
+                    else:
+                        enforcehttps=1
                     # debugging option
                     if 'debug' in options:
                         if options['debug'].lower() in ("yes", "true", "t", "1"):
@@ -325,9 +329,12 @@ def execute():
                                     result['curl_certkey'] = cert[1]
                                 else:
                                     result['curl_cert'] = cert
+                            if enforcehttps:
+                                result['enforcehttps']=enforcehttps
 
                     # enforce HTTPS in uri field
-                    enforceHTTPS(uri)
+                    if enforcehttps and (enforcehttps==1 or enforcehttps==True):
+                        enforceHTTPS(uri)
 
                     # based on method, execute appropriate function
                     if method.lower() in ("get","g"):
@@ -359,7 +366,11 @@ def execute():
                     data = str(options['data'])
                 else:
                     data = None
-
+                # We enable users at their risk to do http queries instead of https, while not recommended it is good to allow users freedom
+                if 'enforcehttps'  in options:
+                    enforcehttps=options['enforcehttps']
+                else:
+                    enforcehttps=1
                 # debug option
                 if 'debug' in options:
                     if options['debug'].lower() in ("yes", "true", "t", "1"):
@@ -379,9 +390,12 @@ def execute():
                                 result['curl_certkey'] = cert[1]
                             else:
                                 result['curl_cert'] = cert
+                        if enforcehttps:
+                                result['enforcehttps']=enforcehttps
 
                 # enforce HTTPS in uri field
-                enforceHTTPS(uri)
+                if enforcehttps and (enforcehttps==1 or enforcehttps==True):
+                    enforceHTTPS(uri)
 
                 # based on method, esecute appropriate function
                 if method.lower() in ("get","g"):

--- a/TA-webtools/default/searchbnf.conf
+++ b/TA-webtools/default/searchbnf.conf
@@ -1,5 +1,5 @@
 [curl-command]
-syntax = CURL [choice:URI=<uri> OR URIFIELD=<urifield>] [optional: METHOD=<GET|PATCH|POST|PUT|DELETE> VERIFYSSL=<TRUE|FALSE> DATAFIELD=<field_name> DATA=<data> HEADERFIELD=<json_header_field_name> HEADERS=<json_header> USER=<user> PASS=<password> DEBUG=<true|false> SPLUNKAUTH=<true|false> SPLUNKPASSWDNAME=<username_in_passwordsconf> SPLUNKPASSWDCONTEXT=<appcontext (optional)> TIMEOUT=<float>]
+syntax = CURL [choice:URI=<uri> OR URIFIELD=<urifield>] [optional: METHOD=<GET|PATCH|POST|PUT|DELETE> VERIFYSSL=<TRUE|FALSE> DATAFIELD=<field_name> DATA=<data> HEADERFIELD=<json_header_field_name> HEADERS=<json_header> USER=<user> PASS=<password> DEBUG=<true|false> SPLUNKAUTH=<true|false> SPLUNKPASSWDNAME=<username_in_passwordsconf> SPLUNKPASSWDCONTEXT=<appcontext (optional)> TIMEOUT=<float>] ENFORCEHTTPS=<true|false>
 alias =
 shortdesc = The curl command allows calling an endpoint and retrieving results
 description = \
@@ -66,6 +66,9 @@ comment10 = \
     Call localhost but retrieve the password from the password store for username example (the real password is never mentioned in this command)
 example10 = \
     | curl method=get uri=https://localhost:8089/services user=example splunkpasswdname=example
+example11 = \
+    | curl enforcehttps=0 method=get uri=http://www.google.com/ 
+
 category = generating,streaming
 #appears-in = 1.2
 usage = public


### PR DESCRIPTION
While it makes sense to have enforced the https parameter, will be great to be able to select if you want to disable the enforcing of HTTPS. We use the ta-webtools to monitor some of our applications and with the change to enforcing HTTPS we have issues monitoring the ones that don't have HTTPS enabled. 