### PR TITLE
Feat: allow proxy details to be passed to command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
 # TA-webtools
 Contains source code for TA-webtools Splunk Add-on
+
+## Splunk Commands
+
+### curl
+The `curl` command allows you to make HTTP requests from within Splunk searches.
+
+#### Required Parameters (One of the following must be specified)
+- `uri`: The HTTPS URL to send the request to
+- `urifield`: Field name containing the HTTPS URL to send the request to
+
+#### Optional Parameters
+- `method`: HTTP method to use (default: get)
+  - Supported values: get/g, head/h, patch, post/p, put, delete/del/d
+- `datafield`: Field name containing the data payload to send
+- `data`: Static data payload to send
+- `debug`: Enable debug output (true/false)
+- `splunkauth`: Use Splunk authentication (true/false)
+- `splunkpasswdname`: Username from passwords.conf to use for authentication
+- `splunkpasswdcontext`: App context for passwords.conf lookup (default: -)
+- `timeout`: Request timeout in seconds (default: 60)
+- `token`: Bearer token for authentication
+- `headers`: JSON string containing request headers
+- `headerfield`: Field containing JSON formatted request headers
+- `clientcert`: Path to client certificate file
+- `certkey`: Path to certificate key file
+- `sleep`: Time to sleep between requests in seconds (when processing multiple events)
+- `proxy`: Proxy URL to use for requests
+- `proxy_auth`: Proxy authentication in format username:password
+
+#### Security Notes
+- All URIs must use HTTPS protocol
+- SSL verification is enforced for Splunk Cloud compatibility
+
+#### Output Fields
+The command adds the following fields to your events:
+- `curl_status`: HTTP status code of the response
+- `curl_message`: Response body or error message
+
+When debug=true, additional fields are added showing the command configuration:
+- `curl_method`: HTTP method used
+- `curl_verifyssl`: SSL verification status
+- `curl_uri`: Request URL
+- `curl_splunkauth`: Whether Splunk authentication was used
+- `curl_data_payload`: Data payload sent (if any)
+- `curl_header`: Headers used (if any)
+- `curl_cert`: Client certificate path (if used)
+- `curl_certkey`: Certificate key path (if used)
+- `curl_sleep`: Sleep duration between requests (if configured)
+
+#### Example Usage
+```spl
+| makeresults 
+| eval url="https://api.example.com/data"
+| curl uri=url method=get
+```
+
+### urlencode
+The `urlencode` command allows you to URL encode field values within your Splunk searches. This is useful when preparing values for use in URLs or API calls.
+
+#### Usage
+The command takes field names as arguments and updates the contents to be URL encoded values.
+
+#### Example Usage
+```spl
+| makeresults 
+| eval my_field="hello world 123"
+| urlencode my_field
+```
+
+This will update the value of my_field to `hello%20world%20123` 

--- a/TA-webtools/bin/curl.py
+++ b/TA-webtools/bin/curl.py
@@ -1,4 +1,3 @@
-
 import json
 import requests
 import splunk.Intersplunk
@@ -25,117 +24,117 @@ def getException(e,uri):
     response['url'] = uri
     return(response)
 
-def get(uri,sessionKey,cert,token=None,headers=None,payload=None,user=None,password=None,timeout=60):
+def get(uri,sessionKey,cert,token=None,headers=None,payload=None,timeout=60,user=None,password=None,proxies=None):
     try:
         if sessionKey == None and token == None:
             if user == None and password == None:
-                r = requests.get(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+                r = requests.get(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
             else:
-                r = requests.get(uri,auth=(user,password),params=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+                r = requests.get(uri,auth=(user,password),params=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
         elif token != None:
             headers = {}
             headers["Authorization"] = "Bearer %s" % token
-            r = requests.get(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+            r = requests.get(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
         else:
             headers = {}
             headers["Authorization"] = "Splunk %s" % sessionKey
-            r = requests.get(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+            r = requests.get(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
         return(getResponse(r,uri))
     except requests.exceptions.RequestException as e:
         return(getException(e,uri))
 
-def head(uri,sessionKey,cert,token=None,headers=None,payload=None,user=None,password=None,timeout=60):
+def head(uri,sessionKey,cert,token=None,headers=None,payload=None,timeout=60,user=None,password=None,proxies=None):
     try:
         if sessionKey == None and token == None:
             if user == None and password == None:
-                r = requests.head(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+                r = requests.head(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
             else:
-                r = requests.head(uri,auth=(user,password),params=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+                r = requests.head(uri,auth=(user,password),params=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
         elif token != None:
             headers = {}
             headers["Authorization"] = "Bearer %s" % token
-            r = requests.head(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout)                
+            r = requests.head(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)                
         else:
             headers = {}
             headers["Authorization"] = "Splunk %s" % sessionKey
-            r = requests.head(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+            r = requests.head(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
         return(getResponse(r,uri))
     except requests.exceptions.RequestException as e:
         return(getException(e,uri))
 
-def patch(uri,sessionKey,cert,token=None,headers=None,payload=None,user=None,password=None,timeout=60):
+def patch(uri,sessionKey,cert,token=None,headers=None,payload=None,timeout=60,user=None,password=None,proxies=None):
     try:
         if sessionKey == None and token == None:
             if user == None and password == None:
-                r = requests.patch(uri,data=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+                r = requests.patch(uri,data=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
             else:
-                r = requests.patch(uri,auth=(user,password),data=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+                r = requests.patch(uri,auth=(user,password),data=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
         elif token != None:
             headers = {}
             headers["Authorization"] = "Bearer %s" % token
-            r = requests.patch(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout)                
+            r = requests.patch(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)                
         else:
             headers = {}
             headers["Authorization"] =  "Splunk %s" % sessionKey
-            r = requests.patch(uri,data=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+            r = requests.patch(uri,data=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
         return(getResponse(r,uri))
     except requests.exceptions.RequestException as e:
         return(getException(e,uri))
 
-def post(uri,sessionKey,cert,token=None,headers=None,payload=None,user=None,password=None,timeout=60):
+def post(uri,sessionKey,cert,token=None,headers=None,payload=None,timeout=60,user=None,password=None,proxies=None):
     try:
         if sessionKey == None and token == None:
             if user == None and password == None:
-                r = requests.post(uri,data=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+                r = requests.post(uri,data=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
             else:
-                r = requests.post(uri,auth=(user,password),data=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+                r = requests.post(uri,auth=(user,password),data=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
         elif token != None:
             headers = {}
             headers["Authorization"] = "Bearer %s" % token
-            r = requests.post(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout)                
+            r = requests.post(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)                
         else:
             headers = {}
             headers["Authorization"] =  "Splunk %s" % sessionKey
-            r = requests.post(uri,data=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+            r = requests.post(uri,data=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
         return(getResponse(r,uri))
     except requests.exceptions.RequestException as e:
         return(getException(e,uri))
 
-def put(uri,sessionKey,cert,token=None,headers=None,payload=None,user=None,password=None,timeout=60):
+def put(uri,sessionKey,cert,token=None,headers=None,payload=None,timeout=60,user=None,password=None,proxies=None):
     try:
         if sessionKey == None and token == None:
             if user == None and password == None:
-                r = requests.put(uri,data=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+                r = requests.put(uri,data=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
             else:
-                r = requests.put(uri,auth=(user,password),data=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+                r = requests.put(uri,auth=(user,password),data=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
         elif token != None:
             headers = {}
             headers["Authorization"] = "Bearer %s" % token
-            r = requests.put(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout)                
+            r = requests.put(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)                
         else:
             headers = {}
             headers["Authorization"] =  "Splunk %s" % sessionKey
-            r = requests.put(uri,data=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+            r = requests.put(uri,data=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
         return(getResponse(r,uri))
     except requests.exceptions.RequestException as e:
         return(getException(e,uri))
 
 
-def delete(uri,sessionKey,cert,token=None,headers=None,payload=None,user=None,password=None,timeout=60):
+def delete(uri,sessionKey,cert,token=None,headers=None,payload=None,timeout=60,user=None,password=None,proxies=None):
     try:
         if sessionKey == None and token == None:
             if user == None and password == None:
-                r = requests.delete(uri,data=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+                r = requests.delete(uri,data=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
             else:
-                r = requests.delete(uri,auth=(user,password),data=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+                r = requests.delete(uri,auth=(user,password),data=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
         elif token != None:
             headers = {}
             headers["Authorization"] = "Bearer %s" % token
-            r = requests.delete(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout)                
+            r = requests.delete(uri,params=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)                
         else:
             headers = {}
             headers["Authorization"] = 'Splunk %s' % sessionKey
-            r = requests.delete(uri,data=payload,verify=True,cert=cert,headers=headers,timeout=timeout)
+            r = requests.delete(uri,data=payload,verify=True,cert=cert,headers=headers,timeout=timeout,proxies=proxies)
         return(getResponse(r,uri))
     except requests.exceptions.RequestException as e:
         return(getException(e,uri))
@@ -145,9 +144,9 @@ def syntaxErr():
     stack =  traceback.format_exc()
     e = "syntax: | curl [ choice: uri=<uri> OR urifield=<urifield> ] " \
     + "[ optional: method=<get | head | patch | post | put | delete> datafield=<datafield> "\
-    + "data=<data> user=<user> pass=<password> debug=<true | false> splunkauth=<true | false> "\
+    + "data=<data> debug=<true | false> splunkauth=<true | false> "\
     + "splunkpasswdname=<username_in_passwordsconf> splunkpasswdcontext=<appcontext> timeout=<float> "\
-    + "token=<splunk_auth_token> ]"
+    + "token=<splunk_auth_token> proxy=<proxy_url> proxy_auth=<username:password> ]"
     splunk.Intersplunk.generateErrorResults(str(e))
     logger.error(str(e) + ". Traceback: " + str(stack))
     return
@@ -169,6 +168,10 @@ def enforceHTTPS(uri=None):
 
 def execute():
     try:
+        # Initialize authentication variables
+        user = None
+        passwd = None
+        
         # get the keywords suplied to the curl command
         argv = splunk.Intersplunk.win32_utf8_argv() or sys.argv
 
@@ -183,6 +186,20 @@ def execute():
             else:
                 result = pattern.match(arg)
                 options[result.group(1)] = result.group(2)
+
+        # Setup proxy configuration if provided
+        proxies = None
+        if 'proxy' in options:
+            proxy_url = options['proxy']
+            if 'proxy_auth' in options:
+                # Split username:password format
+                auth = options['proxy_auth'].split(':')
+                if len(auth) == 2:
+                    proxy_url = proxy_url.replace('://', '://' + auth[0] + ':' + auth[1] + '@')
+            proxies = {
+                'http': proxy_url,
+                'https': proxy_url
+            }
 
         # get the previous search results
         results,dummyresults,settings = splunk.Intersplunk.getOrganizedResults()
@@ -218,20 +235,6 @@ def execute():
             else:
                 cert = None
 
-            # user variable is required, so if not specified, it should = None
-            if 'user' not in options:
-                user = None
-            else:
-                user = options['user']
-
-            # passwd variable is required, so if not specified, it should = None
-            if 'pass' not in options:
-                # handle if user gives "password" instead of "pass"
-                if 'password' in options:
-                    passwd = options['password']
-                passwd = None
-            else:
-                passwd = options['pass']
 
             # splunkpasswdcontext variable is optional, defaults to -
             if 'splunkpasswdcontext' not in options:
@@ -318,6 +321,8 @@ def execute():
                         headers = user_headers
                     else:
                         headers = None
+                    
+                    data = None
 
                     # if data in options, set data = options['data']
                     if 'data' in options:
@@ -329,8 +334,7 @@ def execute():
                             data = json.loads(result[options['datafield']])
                         except:
                             data = str(result[options['datafield']])
-                    else:
-                        data = None
+
 
                     # debugging option
                     if 'debug' in options:
@@ -361,17 +365,17 @@ def execute():
 
                     # based on method, execute appropriate function
                     if method.lower() in ("get","g"):
-                        Result = get(uri,sessionKey,cert,token,headers,data,user,passwd,timeout)
+                        Result = get(uri,sessionKey,cert,token,headers,data,timeout,user,passwd,proxies)
                     if method.lower() in ("head","h"):
-                        Result = head(uri,sessionKey,cert,token,headers,data,user,passwd,timeout)
+                        Result = head(uri,sessionKey,cert,token,headers,data,timeout,user,passwd,proxies)
                     if method.lower() in ("patch"):
-                        Result = patch(uri,sessionKey,cert,token,headers,data,user,passwd,timeout)
+                        Result = patch(uri,sessionKey,cert,token,headers,data,timeout,user,passwd,proxies)
                     if method.lower() in ("post","p"):
-                        Result = post(uri,sessionKey,cert,token,headers,data,user,passwd,timeout)
+                        Result = post(uri,sessionKey,cert,token,headers,data,timeout,user,passwd,proxies)
                     if method.lower() in ("put"):
-                        Result = put(uri,sessionKey,cert,token,headers,data,user,passwd,timeout)
+                        Result = put(uri,sessionKey,cert,token,headers,data,timeout,user,passwd,proxies)
                     if method.lower() in ("delete","del","d"):
-                        Result = delete(uri,sessionKey,cert,token,headers,data,user,passwd,timeout)
+                        Result = delete(uri,sessionKey,cert,token,headers,data,timeout,user,passwd,proxies)
 
                     # append the result to results in the splunk search pipeline
                     result['curl_status'] = Result['status']
@@ -383,7 +387,8 @@ def execute():
                 # build splunk result payload
                 result={}
                 results=[]
-
+                user=None
+                passwd=None
                 # if user specifed data manually
                 if 'data' in options:
                     data = str(options['data'])
@@ -415,17 +420,17 @@ def execute():
 
                 # based on method, esecute appropriate function
                 if method.lower() in ("get","g"):
-                    Result = get(uri,sessionKey,cert,token,user_headers,data,user,passwd,timeout)
+                    Result = get(uri,sessionKey,cert,token,user_headers,data,timeout,user,passwd,proxies)
                 if method.lower() in ("head","h"):
-                    Result = head(uri,sessionKey,cert,token,user_headers,data,user,passwd,timeout)
+                    Result = head(uri,sessionKey,cert,token,user_headers,data,timeout,user,passwd,proxies)
                 if method.lower() in ("patch"):
-                    Result = patch(uri,sessionKey,cert,token,user_headers,data,user,passwd,timeout)
+                    Result = patch(uri,sessionKey,cert,token,user_headers,data,timeout,user,passwd,proxies)
                 if method.lower() in ("post","p"):
-                    Result = post(uri,sessionKey,cert,token,user_headers,data,user,passwd,timeout)
+                    Result = post(uri,sessionKey,cert,token,user_headers,data,timeout,user,passwd,proxies)
                 if method.lower() in ("put"):
-                    Result = put(uri,sessionKey,cert,token,user_headers,data,user,passwd,timeout)
+                    Result = put(uri,sessionKey,cert,token,user_headers,data,timeout,user,passwd,proxies)
                 if method.lower() in ("delete","del","d"):
-                    Result = delete(uri,sessionKey,cert,token,user_headers,data,user,passwd,timeout)
+                    Result = delete(uri,sessionKey,cert,token,user_headers,data,timeout,user,passwd,proxies)
 
                 # append the result to splunk result payload
                 result['curl_status'] = Result['status']

--- a/TA-webtools/default/searchbnf.conf
+++ b/TA-webtools/default/searchbnf.conf
@@ -1,5 +1,5 @@
 [curl-command]
-syntax = CURL [choice:URI=<uri> OR URIFIELD=<urifield>] [optional: METHOD=<GET|PATCH|POST|PUT|DELETE> VERIFYSSL=<TRUE|FALSE> DATAFIELD=<field_name> DATA=<data> HEADERFIELD=<json_header_field_name> HEADERS=<json_header> USER=<user> PASS=<password> DEBUG=<true|false> SPLUNKAUTH=<true|false> SPLUNKPASSWDNAME=<username_in_passwordsconf> SPLUNKPASSWDCONTEXT=<appcontext> TIMEOUT=<float> token=<splunk_auth_token>]
+syntax = CURL [choice:URI=<uri> OR URIFIELD=<urifield>] [optional: METHOD=<GET|PATCH|POST|PUT|DELETE> VERIFYSSL=<TRUE|FALSE> DATAFIELD=<field_name> DATA=<data> HEADERFIELD=<json_header_field_name> HEADERS=<json_header> USER=<user> PASS=<password> DEBUG=<true|false> SPLUNKAUTH=<true|false> SPLUNKPASSWDNAME=<username_in_passwordsconf> SPLUNKPASSWDCONTEXT=<appcontext> TIMEOUT=<float> TOKEN=<splunk_auth_token> PROXY=<proxy_url> PROXY_AUTH=<username:password>]
 alias =
 shortdesc = The curl command allows calling an endpoint and retrieving results
 description = \
@@ -7,8 +7,9 @@ description = \
     using the GET, PATCH, POST, PUT or DELETE HTTP methods \
     The user= option can be used to pass in a username, pass= for password, or alternatively  \
     splunkpasswdname= to search the passwords.conf or the required username and use the password from it\
-    headers= is used to supply headers in JSON format, this can be used to provide HTTP headers to be used, headerfield= ensures the curl command uses the named Splunk field for header data
-    splunkpasswdcontext= is not required to use splunkpasswdname but can force the app context to look for the password in
+    headers= is used to supply headers in JSON format, this can be used to provide HTTP headers to be used, headerfield= ensures the curl command uses the named Splunk field for header data\
+    splunkpasswdcontext= is not required to use splunkpasswdname but can force the app context to look for the password in\
+    proxy= allows specifying a proxy server URL, and proxy_auth= can be used to provide proxy authentication credentials
 comment1 = \
     GET data from uri, specifing user, pass, and very short timeout
 example1 = \
@@ -66,6 +67,10 @@ comment10 = \
     Call localhost but retrieve the password from the password store for username example (the real password is never mentioned in this command)
 example10 = \
     | curl method=get uri=https://localhost:8089/services user=example splunkpasswdname=example
+comment11 = \
+    Make a request through a proxy server with authentication
+example11 = \
+    | curl method=get uri=https://api.example.com/data proxy=http://proxy.company.com:8080 proxy_auth=proxyuser:proxypass
 category = generating,streaming
 #appears-in = 1.2
 usage = public


### PR DESCRIPTION
This allows a proxy param to be sent to the curl command, removing the need for HTTP_PROXY/HTTPS_PROXY to be specified in /opt/splunk/etc/splunk-launch.conf
Sometimes only specific URLs require a proxy.
